### PR TITLE
use setter to avoid deprication warning

### DIFF
--- a/addon/mixins/child.js
+++ b/addon/mixins/child.js
@@ -7,8 +7,17 @@ export default Mixin.create({
 
   // This is intended as an escape hatch, but ideally you would
   // `{{yield` a child contextual component with `parentComponent=this`
-  parentComponent: computed(function() {
-    return this.nearestOfType(ParentMixin);
+  parentComponent: computed({
+    get() {
+      if (this._parentComponent) {
+        return this._parentComponent;
+      }
+      return this.nearestOfType(ParentMixin);
+    },
+    set(key, value) {
+      this._parentComponent = value;
+      return this._parentComponent;
+    }
   }),
 
   init() {


### PR DESCRIPTION
This PR removes a depreciation warning about overriding a computed property. Fix is described in this [deprecations](https://deprecations.emberjs.com/v3.x/#toc_computed-property-override) article.